### PR TITLE
leverage a multi-stage docker build process

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
+FROM maven:3.8.1-openjdk-17 as builder
+
+COPY . /src
+RUN cd /src && \
+  mvn clean && \
+  mvn package
+
 FROM openjdk:17-jdk-alpine3.13
+
 RUN addgroup -S spring && adduser -S spring -G spring
 USER spring:spring
-ARG JAR_FILE=target/*.jar
-COPY ${JAR_FILE} app.jar
+COPY --from=builder /src/target/*.jar /app.jar
 ENTRYPOINT ["java","-jar","/app.jar"]

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,5 @@
-clean:
-	mvn clean
-
-package: clean
-	mvn package
-
-build-docker: package
-	docker build --build-arg JAR_FILE=target/\*.jar -t example/spring-boot-graphite .
+build-docker:
+	docker build -t example/spring-boot-graphite .
 
 run: build-docker
 	docker-compose up
-


### PR DESCRIPTION
This saves users from needing any pre-installed
dependencies beyond Docker (and Make, I suppose).